### PR TITLE
RSPY-687 - Promtail/Loki/Tempo: enable "Trace to logs" in Grafana

### DIFF
--- a/apps/grafana-tempo/grafanadatasource.yaml
+++ b/apps/grafana-tempo/grafanadatasource.yaml
@@ -28,5 +28,22 @@ spec:
     url: http://grafana-tempo-query-frontend.logging.svc.cluster.local:3100
     isDefault: false
     jsonData:
+      lokiSearch:
+        datasourceUid: "Loki"
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: "Prometheus"
+      tracesToLogsV2:
+        datasourceUid: "Loki"
+        filterBySpanID:	true
+        filterByTraceID: true
+        spanEndTimeShift: "1m"
+        spanStartTimeShift: "-1m"
+        tags:
+          - key: "service.name"
+            value: "service_name"
+          - key: "pod"
+            value: ""
       "tlsSkipVerify": true
       "timeInterval": "5s"

--- a/apps/loki-distributed/grafanadatasource.yaml
+++ b/apps/loki-distributed/grafanadatasource.yaml
@@ -28,5 +28,12 @@ spec:
     url: http://loki-distributed-query-frontend.logging.svc.cluster.local:3100
     isDefault: false
     jsonData:
+      derivedFields:
+        - name: "span_id"
+          matcherRegex: "span_id=(\\w+)"
+        - name: "trace_id"
+          matcherRegex: "trace_id=(\\w+)"
+          url: "${__value.raw}"
+          datasourceUid: "tempo"
       "tlsSkipVerify": true
       "timeInterval": "5s"

--- a/apps/promtail/values.yaml
+++ b/apps/promtail/values.yaml
@@ -81,7 +81,7 @@ config:
               service_name:
           - template:
               source: output_msg
-              template: '{{ .otel }} {{ .logger }} {{ .msg }}'
+              template: '{{ "{{" }} .otel {{ "}}" }} {{ "{{" }} .logger {{ "}}" }} {{ "{{" }} .msg {{ "}}" }}'
           - output:
               source: output_msg
 

--- a/apps/promtail/values.yaml
+++ b/apps/promtail/values.yaml
@@ -57,6 +57,33 @@ tolerations:
 config:
   clients:
     - url: http://loki-distributed-gateway.logging.svc.cluster.local/loki/api/v1/push
+  snippets:
+    # Must follow _FORMAT in https://github.com/RS-PYTHON/rs-server/blob/develop/services/common/rs_server_common/utils/logging.py
+    # https://grafana.com/docs/loki/latest/send-data/promtail/stages/
+    pipelineStages:
+      - cri: {}
+      - match:
+          selector: '{app=~"rs-.+"} |~ ".*trace_id.*"'
+          stages:
+          - regex:
+              expression: ^(?P<ts>\S+) .+\dm(?P<level>\w+).+0m \[(?P<otel>[^\]]+)\] \((?P<logger>[^\)]+)\) (?P<msg>.*)$
+              source: content
+          - labels:
+              level:
+              logger:
+          - logfmt:
+              mapping:
+                trace_sampled:
+                service_name: resource.service.name
+              source: otel
+          - labels:
+              trace_sampled:
+              service_name:
+          - template:
+              source: output_msg
+              template: '{{ .otel }} {{ .logger }} {{ .msg }}'
+          - output:
+              source: output_msg
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
To use with https://github.com/RS-PYTHON/rs-server/pull/1262

This allows to enable the "Logs for this span" in Grafana Tempo:

![image](https://github.com/user-attachments/assets/9f1e44d7-128a-4dc9-8393-05913e07167b)

which redirects to Loki and filters by trace_id / span_id:

![image](https://github.com/user-attachments/assets/9343714c-adc8-4aca-bff3-cd806eb36b02)
