### PR TITLE
Fix/alloy

### DIFF
--- a/apps/alloy/values.yaml
+++ b/apps/alloy/values.yaml
@@ -229,11 +229,12 @@ alloy:
         stage.cri { }
 
         stage.match {
-          selector = "{app=~\"rs-.+\"} |~ \".*trace_id.*\""
+
+          selector = "{app=~\"rs-.+\", content=~\".*trace_id.*\"}"
 
           stage.regex {
             expression = "^(?P<ts>\\S+) .+\\dm(?P<level>\\w+).+0m \\[(?P<otel>[^\\]]+)\\] \\((?P<logger>[^\\)]+)\\) (?P<msg>.*)$"
-            source     = "content"
+            source = "content"
           }
 
           stage.labels {
@@ -268,4 +269,3 @@ alloy:
           }
         }
       }
-

--- a/apps/alloy/values.yaml
+++ b/apps/alloy/values.yaml
@@ -226,15 +226,16 @@ alloy:
 
         forward_to = [loki.write.k8s.receiver]
 
-        stage.cri { }
-
         stage.match {
 
-          selector = "{app=~\"rs-.+\", content=~\".*trace_id.*\"}"
+          selector = "{app=~\"rs-.+\"}"
+
+          stage.cri {}
+
+          stage.decolorize {}
 
           stage.regex {
-            expression = "^(?P<ts>\\S+) .+\\dm(?P<level>\\w+).+0m \\[(?P<otel>[^\\]]+)\\] \\((?P<logger>[^\\)]+)\\) (?P<msg>.*)$"
-            source = "content"
+            expression = "^(?s)(?P<time>\\S+?) (?P<level>DEBUG|INFO|WARNING|ERROR|CRITICAL) \\[(?P<otel>.+?)\\] \\((?P<logger>.+?)\\) (?P<msg>.*)$"
           }
 
           stage.labels {
@@ -259,13 +260,33 @@ alloy:
             }
           }
 
-          stage.template {
-            source   = "output_msg"
-            template = "{% raw %}{{ .otel }} {{ .logger }} {{ .msg }}{% endraw %}"
-          }
+          // The following is not working because {{ and }} are interpreted by jinja when using ansible
+          // The workround with {% raw %} and {% endraw %} is not working here for unknown reason
+          //stage.template {
+          //  source   = "output_msg"
+          //  template = "{% raw %}{{ .otel }} {{ .logger }} {{ .msg }}{% endraw %}"
+          //}
 
-          stage.output {
-            source = "output_msg"
+          //stage.output {
+          //  source = "output_msg"
+          //}
+
+          stage.label_drop {
+            values = [ "otel", "span_id", "msg", "logger" ]
           }
+        }
+
+        stage.match {
+            selector = "{app!~\"rs-.+\"}"
+            action   = "drop"
+
+            drop_counter_reason = "not_rs_traces"
+        }
+
+        stage.match {
+            selector = "{detected_lev=\"info\"}"
+            action   = "drop"
+
+            drop_counter_reason = "not_traces"
         }
       }

--- a/apps/alloy/values.yaml
+++ b/apps/alloy/values.yaml
@@ -260,7 +260,7 @@ alloy:
             }
           }
 
-          // The following is not working because {{ and }} are interpreted by jinja when using ansible
+          // The following is not working because the double curly backets are interpreted by jinja when using ansible
           // The workround with {% raw %} and {% endraw %} is not working here for unknown reason
           //stage.template {
           //  source   = "output_msg"


### PR DESCRIPTION
Remaining bug :

The following is not working because {{ and }} are interpreted by jinja when using ansible
The workround with {% raw %} and {% endraw %} is not working here for unknown reason
```hcl
stage.template {
  source   = "output_msg"
  template = "{% raw %}{{ .otel }} {{ .logger }} {{ .msg }}{% endraw %}"
}
stage.output {
  source = "output_msg"
}
```