### PR TITLE
Reduce allocated requests to minio, loki and prometheus in ci/cd

### DIFF
--- a/.github/common/resources/configure-minikube-deployment.sh
+++ b/.github/common/resources/configure-minikube-deployment.sh
@@ -18,16 +18,22 @@ set -euo pipefail
 APPS=rs-infra-monitoring/apps
 
 # Lower the CPU requests
-sed -i 's!cpu: 200m!cpu: 1m!g' "${APPS}/grafana/grafana.yaml"
-sed -i 's!cpu: 50m!cpu: 1m!g' "${APPS}/grafana/image-renderer.yaml"
-sed -i 's!cpu: 500m!cpu: 1m!g' "${APPS}/prometheus/values.yaml"
-# Lower the number of loki replicas
+sed -i -e 's!cpu: 200m!cpu: 1m!g' -e 's!memory: 256Mi!memory: 128Mi!g' "${APPS}/grafana/grafana.yaml"
+sed -i -e 's!cpu: 50m!cpu: 1m!g' -e 's!memory: 128Mi!memory: 64Mi!g' "${APPS}/grafana/image-renderer.yaml"
+sed -i -e 's!cpu: 500m!cpu: 1m!g' -e 's!memory: 512Mi!memory: 128Mi!g' "${APPS}/prometheus/values.yaml"
+# Lower the requests and number of loki replicas
 sed -i \
     -e 's!max_concurrent: 4!max_concurrent: 1!g' \
     -e 's!replicas: 3!replicas: 1!g' \
     -e 's!replicas: 2!replicas: 1!g' \
     -e 's!maxUnavailable: 2!maxUnavailable: 0!g' \
     -e 's!maxUnavailable: 1!maxUnavailable: 0!g' \
+    -e 's!cpu: 500m!cpu: 5m!g' \
+    -e 's!allocatedMemory: 8192!allocatedMemory: 100!g' \
+    -e 's!allocatedMemory: 1024!allocatedMemory: 100!g' \
+    -e 's!memory: 1229Mi!memory: 120Mi!g' \
+    -e 's!memory: 9830Mi!memory: 120Mi!g' \
+    -e 's!writebackSizeLimit: 500MB!writebackSizeLimit: 50MB!g' \
     "${APPS}/loki/values.yaml"
 # Disable strict podAntiAffinity loki directives that prevent to deploy on a single node
 # see https://github.com/grafana/helm-charts/issues/2709#issuecomment-2839130975

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -44,7 +44,9 @@ jobs:
         id: cache-conda
         uses: actions/cache@v4
         with:
-          path: ~/miniforge3
+          path: |
+            ~/miniforge3
+            /usr/share/miniconda
           key: conda-${{ runner.os }}-${{ hashFiles('.github/common/resources/install-requirements.sh') }}
           restore-keys: |
             conda-${{ runner.os }}-
@@ -68,7 +70,7 @@ jobs:
           # Minio for cloudnative pg and loki/tempo - https://github.com/minio/minio/tree/master/helm/minio#installing-the-chart-toy-setup
           helm repo add minio https://charts.min.io/
           helm repo update minio
-          helm install minio minio/minio --namespace minio --set mode=standalone --set replicas=1 --set persistence.enabled=false --set resources.requests.memory=512Mi --set rootUser=s3_access_key,rootPassword=s3_secret_key --set buckets[0].name=rs-cluster-psql,buckets[1].name=rs-cluster-velero,buckets[2].name=rs-cluster-loki-chunks,buckets[3].name=rs-cluster-loki-ruler,buckets[4].name=rs-cluster-tempo --create-namespace --wait
+          helm install minio minio/minio --namespace minio --set mode=standalone --set replicas=1 --set persistence.enabled=false --set resources.requests.memory=128Mi --set rootUser=s3_access_key,rootPassword=s3_secret_key --set buckets[0].name=rs-cluster-psql,buckets[1].name=rs-cluster-velero,buckets[2].name=rs-cluster-loki-chunks,buckets[3].name=rs-cluster-loki-ruler,buckets[4].name=rs-cluster-tempo --create-namespace --wait
       - name: Generate inventory
         run: |
           .github/common/resources/configure-inventory.sh

--- a/apps/loki/values.yaml
+++ b/apps/loki/values.yaml
@@ -52,7 +52,12 @@ loki:
 deploymentMode: Distributed
 
 ingester:
+  # -- Number of replicas for the ingester
   replicas: 3
+  # -- Resource requests and limits for the ingester
+  resources: {}
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   zoneAwareReplication:
     enabled: false
   affinity:
@@ -64,7 +69,11 @@ ingester:
               operator: Exists
 
 querier:
+  # -- Number of replicas for the querier
   replicas: 3
+  # -- Resource requests and limits for the querier
+  resources: {}
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 2
   affinity:
     nodeAffinity:
@@ -75,7 +84,11 @@ querier:
               operator: Exists
 
 queryFrontend:
+  # -- Number of replicas for the query-frontend
   replicas: 2
+  # -- Resource requests and limits for the query-frontend
+  resources: {}
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   affinity:
     nodeAffinity:
@@ -86,7 +99,14 @@ queryFrontend:
               operator: Exists
 
 queryScheduler:
+  # -- Number of replicas for the query-scheduler.
+  # It should be lower than `-querier.max-concurrent` to avoid generating back-pressure in queriers;
+  # it's also recommended that this value evenly divides the latter
   replicas: 2
+  # -- Resource requests and limits for the query-scheduler
+  resources: {}
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -96,7 +116,11 @@ queryScheduler:
               operator: Exists
 
 distributor:
+  # -- Number of replicas for the distributor
   replicas: 3
+  # -- Resource requests and limits for the distributor
+  resources: {}
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 2
   affinity:
     nodeAffinity:
@@ -107,7 +131,10 @@ distributor:
               operator: Exists
 
 compactor:
+  # -- Number of replicas for the compactor
   replicas: 1
+  # -- Resource requests and limits for the compactor
+  resources: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -117,7 +144,11 @@ compactor:
               operator: Exists
 
 indexGateway:
+  # -- Number of replicas for the index-gateway
   replicas: 2
+  # -- Resource requests and limits for the index-gateway
+  resources: {}
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   affinity:
     nodeAffinity:
@@ -128,6 +159,17 @@ indexGateway:
               operator: Exists
 
 chunksCache:
+  # -- Total number of chunks-cache replicas
+  replicas: 1
+  # -- Amount of memory allocated to chunks-cache for object storage (in MB).
+  allocatedMemory: 8192
+  # -- Max memory to use for cache write back
+  writebackSizeLimit: 500MB
+  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  resources:
+    requests:
+      cpu: 500m
+      memory: 9830Mi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -137,6 +179,8 @@ chunksCache:
               operator: Exists
 
 gateway:
+  # -- Number of replicas for the gateway
+  replicas: 1
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -146,6 +190,18 @@ gateway:
               operator: Exists
 
 resultsCache:
+  # -- Total number of results-cache replicas
+  replicas: 1
+  # -- Amount of memory allocated to results-cache for object storage (in MB).
+  allocatedMemory: 1024
+  # -- Max memory to use for cache write back
+  writebackSizeLimit: 500MB
+  # -- Resource requests and limits for the results-cache
+  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1229Mi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The current resources requested for minio, loki and prometheus in ci/cd are high regarding limited minikube possibilities in Github actions:

```
=== 🔬 Pods resource requests/limits ===
NAMESPACE        POD                                                      CPU_REQ   CPU_LIM   MEM_REQ   MEM_LIM
minio            minio-5d8ff5b7c7-l8njs                                   <none>    <none>    512Mi     <none>
logging          loki-chunks-cache-0                                      500m      <none>    9830Mi    9830Mi
logging          loki-results-cache-0                                     500m      <none>    1229Mi    1229Mi
monitoring       grafana-deployment-7b5c74789d-bcc86                      1m        500m      256Mi     1Gi
monitoring       grafana-image-renderer-5d45bf65f5-rzwlh                  1m        2         128Mi     1Gi
monitoring       prometheus-prometheus-kube-prometheus-prometheus-0       1m        1         512Mi     2Gi
```

With this PR it becomes:

```
=== 🔬 Pods resource requests/limits ===
NAMESPACE        POD                                                      CPU_REQ   CPU_LIM   MEM_REQ   MEM_LIM
minio            minio-57bd576c9-f7q4z                                    <none>    <none>    128Mi     <none>
logging          loki-chunks-cache-0                                      5m        <none>    120Mi     <none>
logging          loki-results-cache-0                                     5m        <none>    120Mi     <none>
monitoring       grafana-deployment-6759bc664d-49nsd                      1m        500m      128Mi     1Gi
monitoring       grafana-image-renderer-6978fdb49b-5j22n                  1m        2         64Mi      1Gi
monitoring       prometheus-prometheus-kube-prometheus-prometheus-0       1m        1         128Mi     2Gi
```

Default values copied from https://github.com/grafana/loki/blob/v3.5.2/production/helm/loki/values.yaml