### PR TITLE
Fix924-ServiceWithout Pod fix for prometheus and loki

### DIFF
--- a/apps/loki/values.yaml
+++ b/apps/loki/values.yaml
@@ -238,3 +238,7 @@ write:
 
 singleBinary:
   replicas: 0
+
+ruler:
+  # -- The ruler component is optional and can be disabled if desired.
+  enabled: false

--- a/apps/prometheus/values.yaml
+++ b/apps/prometheus/values.yaml
@@ -139,3 +139,15 @@ prometheus:
         scrape_interval: 30s
         static_configs:
             - targets: ["neuvector-prometheus-exporter.security.svc.cluster.local:8068"]
+
+kubeEtcd:
+  enabled: false
+
+kubeControllerManager:
+  enabled: false
+
+kubeScheduler:
+  enabled: false
+
+kubeProxy:
+  enabled: false


### PR DESCRIPTION
See https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-924
**PROMETHEUS**
Desactivate service deployment for 

- kube-proxy
- kube-etcd
- kube-scheduler
- kube-controller-manager

**LOKI**
Desactivate loki ruler