### PR TITLE
Revert "Update to kube-prometheus-stack 82.4.2"

### DIFF
--- a/apps/prometheus/kustomization.yaml
+++ b/apps/prometheus/kustomization.yaml
@@ -18,6 +18,6 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://prometheus-community.github.io/helm-charts
   valuesFile: values.yaml
-  version: 82.4.2
+  version: 58.0.0
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Reverts RS-PYTHON/rs-infra-monitoring#40

This bring an update to Prometheus 3.x which will certainly break Alloy if we don't update it as well.